### PR TITLE
feat: Deprecate text_arg field in favor of text_flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,10 +90,10 @@ quickly. However, with nvim-external-tui, integration looks like this:
 local external_tui = require('external-tui')
 
 local config = external_tui.add({
-  user_cmd = 'Neatui',         -- Creates :Neatui command
-  cmd = 'neatui',              -- External command to run
-  text_arg = '--prefill-text', -- Flag to pass selected/input text to the command
-  editor_command = '--editor', -- Flag for configuring the external editor
+  user_cmd = 'Neatui',          -- Creates :Neatui command
+  cmd = 'neatui',               -- External command to run
+  text_flag = '--prefill-text', -- Flag to pass selected/input text to the command
+  editor_command = '--editor',  -- Flag for configuring the external editor
 })
 ```
 
@@ -132,7 +132,7 @@ use to perform actions automatically:
 external_tui.add({
   user_cmd = 'Neatui',
   cmd = 'neatui',
-  text_arg = '--prefill-text',
+  text_flag = '--prefill-text',
   editor_flag = '--editor',
 
   -- Called before launching the TUI
@@ -160,7 +160,7 @@ Register a new external TUI tool integration.
 |--------|------|----------|---------|-------------|
 | `user_cmd` | `string` | Yes | - | Neovim command name (e.g., 'Scooter' creates `:Scooter`) |
 | `cmd` | `string` | Yes | - | External command to execute (e.g., 'scooter') |
-| `text_arg` | `string` | No | `nil` | Flag for passing search text (e.g., '--search-text') |
+| `text_flag` | `string` | No | `nil` | Flag for passing selected text (e.g., '--search-text') |
 | `editor_flag` | `string` | No | `nil` | Flag for passing editor command (e.g., '--editor') |
 | `file_format` | `string` | No | `'%file'` | Template variable for file path in tool's config |
 | `line_format` | `string` | No | `'%line'` | Template variable for line number in tool's config |
@@ -188,7 +188,7 @@ local external_tui = require('external-tui')
 external_tui.add({
   user_cmd = 'Scooter',
   cmd = 'scooter',
-  text_arg = '--search-text',
+  text_flag = '--search-text',
   editor_flag = '--editor-command',
 })
 ```

--- a/lua/external-tui.lua
+++ b/lua/external-tui.lua
@@ -40,9 +40,15 @@ function M.add(opts)
   assert(opts.user_cmd, 'user_cmd is required')
   assert(opts.cmd, 'cmd is required')
 
+  -- Handle deprecated text_arg option
+  if opts.text_arg then
+    vim.deprecate('text_arg', 'text_flag', '1.0', 'external-tui', false)
+    opts.text_flag = opts.text_flag or opts.text_arg
+  end
+
   local user_cmd = opts.user_cmd
   local cmd = opts.cmd
-  local text_arg = opts.text_arg
+  local text_flag = opts.text_flag
   local editor_flag = opts.editor_flag
   local file_format = opts.file_format or '%file'
   local line_format = opts.line_format or '%line'
@@ -80,10 +86,10 @@ function M.add(opts)
 
     -- Build command with search text if provided
     local launch_cmd = full_cmd
-    if search_text and text_arg then
+    if search_text and text_flag then
       -- Escape the search text for shell
       local escaped_text = vim.fn.shellescape(search_text)
-      launch_cmd = launch_cmd .. ' ' .. text_arg .. ' ' .. escaped_text
+      launch_cmd = launch_cmd .. ' ' .. text_flag .. ' ' .. escaped_text
     end
 
     -- Open terminal and store reference


### PR DESCRIPTION
This brings these fields more in sync with eachother. It was driving me nuts that they were different. We'll remove the old version in 1.0.