### PR TITLE
Move Snacks to an optional dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ where nvim-external-tui comes in.
 {
   'gfontenot/nvim-external-tui',
   dependencies = {
-    'folke/snacks.nvim', -- Required for terminal management
+    'folke/snacks.nvim', -- Optional: provides enhanced terminal management
   },
   config = function()
     -- Your tool configurations here
@@ -46,7 +46,7 @@ where nvim-external-tui comes in.
 use {
   'gfontenot/nvim-external-tui',
   requires = {
-    'folke/snacks.nvim', -- Required for terminal management
+    'folke/snacks.nvim', -- Optional: provides enhanced terminal management
   },
   config = function()
     -- Your tool configurations here
@@ -205,7 +205,7 @@ command = "nvim --server $NVIM --remote-send '<cmd>lua EditLineFromScooter(\"%fi
 ## Requirements
 
 - Neovim >= 0.9.0
-- [snacks.nvim](https://github.com/folke/snacks.nvim) for terminal management
+- [snacks.nvim](https://github.com/folke/snacks.nvim) (optional) - If installed, snacks.nvim will be used for terminal management. Otherwise, a builtin floating terminal is used.
 
 ## Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,24 @@ use {
 }
 ```
 
+## Configuration
+
+The plugin works out of the box with no configuration required. If you want to
+explicitly set the terminal provider, you can use the `setup` function:
+
+```lua
+require('external-tui').setup({
+  terminal_provider = 'builtin', -- 'snacks' | 'builtin' | nil (auto-detect)
+})
+```
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `terminal_provider` | `string?` | `nil` | Terminal backend: `'snacks'`, `'builtin'`, or `nil` for auto-detection |
+
+When set to `nil` (the default), the plugin will use snacks.nvim if available,
+otherwise it falls back to the builtin floating terminal.
+
 ## Usage
 
 ### Basic Example

--- a/lua/external-tui.lua
+++ b/lua/external-tui.lua
@@ -93,7 +93,7 @@ function M.add(opts)
     end
 
     -- Open terminal and store reference
-    terminals[user_cmd] = require('snacks').terminal.open(launch_cmd, { win = { style = 'float' } })
+    terminals[user_cmd] = require('external-tui.terminal').open(launch_cmd)
   end
 
   -- Register the global callback function
@@ -101,7 +101,7 @@ function M.add(opts)
     -- Close the terminal if it's open
     local term = terminals[user_cmd]
     if term and not term.closed then
-      term:toggle()
+      term:close()
     end
 
     -- Check if file is already open to avoid redundant operations

--- a/lua/external-tui.lua
+++ b/lua/external-tui.lua
@@ -1,7 +1,20 @@
 local M = {}
 
+-- Plugin configuration
+local config = {
+  terminal_provider = nil, -- nil = auto-detect, 'snacks', or 'builtin'
+}
+
 -- Store terminal references for each registered tool
 local terminals = {}
+
+-- Configure the plugin
+function M.setup(opts)
+  opts = opts or {}
+  if opts.terminal_provider then
+    config.terminal_provider = opts.terminal_provider
+  end
+end
 
 -- Extract text from visual selection
 local function get_visual_selection()
@@ -93,7 +106,9 @@ function M.add(opts)
     end
 
     -- Open terminal and store reference
-    terminals[user_cmd] = require('external-tui.terminal').open(launch_cmd)
+    terminals[user_cmd] = require('external-tui.terminal').open(launch_cmd, {
+      provider = config.terminal_provider,
+    })
   end
 
   -- Register the global callback function

--- a/lua/external-tui/terminal.lua
+++ b/lua/external-tui/terminal.lua
@@ -1,0 +1,76 @@
+local M = {}
+
+-- Check if snacks.nvim is available
+local has_snacks, snacks = pcall(require, 'snacks')
+
+-- Builtin floating terminal implementation
+local function open_builtin_terminal(cmd)
+  local width = math.floor(vim.o.columns * 0.8)
+  local height = math.floor(vim.o.lines * 0.8)
+  local row = math.floor((vim.o.lines - height) / 2)
+  local col = math.floor((vim.o.columns - width) / 2)
+
+  local buf = vim.api.nvim_create_buf(false, true)
+  local win = vim.api.nvim_open_win(buf, true, {
+    relative = 'editor',
+    width = width,
+    height = height,
+    row = row,
+    col = col,
+    style = 'minimal',
+    border = 'rounded',
+  })
+
+  vim.api.nvim_set_option_value('winhl', 'Normal:Normal', { win = win })
+
+  local term = {
+    buf = buf,
+    win = win,
+    closed = false,
+  }
+
+  ---@diagnostic disable-next-line: deprecated
+  vim.fn.termopen(cmd, {
+    on_exit = function()
+      term.closed = true
+    end,
+  })
+
+  vim.cmd('startinsert')
+
+  function term:close()
+    if vim.api.nvim_win_is_valid(self.win) then
+      vim.api.nvim_win_close(self.win, true)
+    end
+    if vim.api.nvim_buf_is_valid(self.buf) then
+      vim.api.nvim_buf_delete(self.buf, { force = true })
+    end
+    self.closed = true
+  end
+
+  return term
+end
+
+-- Open terminal using best available backend
+function M.open(cmd)
+  if has_snacks then
+    local term = snacks.terminal.open(cmd, { win = { style = 'float' } })
+    return {
+      closed = term.closed,
+      close = function(self)
+        term:toggle()
+        self.closed = true
+      end,
+    }
+  else
+    return open_builtin_terminal(cmd)
+  end
+end
+
+-- Expose for testing
+M._private = {
+  open_builtin_terminal = open_builtin_terminal,
+  has_snacks = has_snacks,
+}
+
+return M

--- a/tests/integration/add_callback_spec.lua
+++ b/tests/integration/add_callback_spec.lua
@@ -10,6 +10,7 @@ describe('M.add return value and callbacks', function()
         end,
       },
     }
+    package.loaded['external-tui.terminal'] = nil
     package.loaded['external-tui'] = nil
     external_tui = require('external-tui')
   end)
@@ -21,6 +22,7 @@ describe('M.add return value and callbacks', function()
     pcall(vim.api.nvim_del_user_command, 'TestCmd')
     pcall(vim.api.nvim_del_user_command, 'Custom')
     package.loaded['snacks'] = nil
+    package.loaded['external-tui.terminal'] = nil
     package.loaded['external-tui'] = nil
   end)
 
@@ -86,6 +88,7 @@ describe('callback function behavior', function()
         end,
       },
     }
+    package.loaded['external-tui.terminal'] = nil
     package.loaded['external-tui'] = nil
     external_tui = require('external-tui')
   end)
@@ -94,6 +97,7 @@ describe('callback function behavior', function()
     _G['EditLineFromTestCmd'] = nil
     pcall(vim.api.nvim_del_user_command, 'TestCmd')
     package.loaded['snacks'] = nil
+    package.loaded['external-tui.terminal'] = nil
     package.loaded['external-tui'] = nil
   end)
 

--- a/tests/integration/add_command_creation_spec.lua
+++ b/tests/integration/add_command_creation_spec.lua
@@ -10,6 +10,7 @@ describe('M.add command creation', function()
         end,
       },
     }
+    package.loaded['external-tui.terminal'] = nil
     package.loaded['external-tui'] = nil
     external_tui = require('external-tui')
   end)
@@ -21,6 +22,7 @@ describe('M.add command creation', function()
     _G['EditLineFromTestCmd'] = nil
     _G['EditLineFromAnotherCmd'] = nil
     package.loaded['snacks'] = nil
+    package.loaded['external-tui.terminal'] = nil
     package.loaded['external-tui'] = nil
   end)
 

--- a/tests/integration/add_validation_spec.lua
+++ b/tests/integration/add_validation_spec.lua
@@ -10,12 +10,14 @@ describe('M.add validation', function()
         end,
       },
     }
+    package.loaded['external-tui.terminal'] = nil
     package.loaded['external-tui'] = nil
     external_tui = require('external-tui')
   end)
 
   after_each(function()
     package.loaded['snacks'] = nil
+    package.loaded['external-tui.terminal'] = nil
     package.loaded['external-tui'] = nil
   end)
 

--- a/tests/integration/setup_spec.lua
+++ b/tests/integration/setup_spec.lua
@@ -1,0 +1,66 @@
+describe('M.setup', function()
+  local external_tui
+
+  before_each(function()
+    -- Mock snacks dependency
+    package.loaded['snacks'] = {
+      terminal = {
+        open = function()
+          return { closed = false, toggle = function() end }
+        end,
+      },
+    }
+    package.loaded['external-tui.terminal'] = nil
+    package.loaded['external-tui'] = nil
+    external_tui = require('external-tui')
+  end)
+
+  after_each(function()
+    _G['EditLineFromTestCmd'] = nil
+    pcall(vim.api.nvim_del_user_command, 'TestCmd')
+    package.loaded['snacks'] = nil
+    package.loaded['external-tui.terminal'] = nil
+    package.loaded['external-tui'] = nil
+  end)
+
+  it('exists as a function', function()
+    assert.is_function(external_tui.setup)
+  end)
+
+  it('accepts empty options', function()
+    assert.has_no_error(function()
+      external_tui.setup({})
+    end)
+  end)
+
+  it('accepts nil options', function()
+    assert.has_no_error(function()
+      external_tui.setup()
+    end)
+  end)
+
+  it('accepts terminal_provider option', function()
+    assert.has_no_error(function()
+      external_tui.setup({ terminal_provider = 'builtin' })
+    end)
+  end)
+end)
+
+describe('terminal provider selection', function()
+  before_each(function()
+    package.loaded['snacks'] = nil
+    package.loaded['external-tui.terminal'] = nil
+    package.loaded['external-tui'] = nil
+  end)
+
+  after_each(function()
+    package.loaded['snacks'] = nil
+    package.loaded['external-tui.terminal'] = nil
+    package.loaded['external-tui'] = nil
+  end)
+
+  it('terminal module exposes has_snacks for testing', function()
+    local terminal = require('external-tui.terminal')
+    assert.is_boolean(terminal._private.has_snacks)
+  end)
+end)


### PR DESCRIPTION
Instead of having a hard dependency on Snacks for the terminal provider, we can use it if it's available but fall back to a custom terminal if necessary.

Supercedes: #5 (thank you @hydra0xetc!)