### PR TITLE
feat: Allow for customization of the terminal presentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,54 @@ require('external-tui').setup({
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `terminal_provider` | `string?` | `nil` | Terminal backend: `'snacks'`, `'builtin'`, or `nil` for auto-detection |
+| `terminal_provider` | `string` or `table` | `nil` | Terminal backend: `'snacks'`, `'builtin'`, `nil` for auto-detection, or a table with provider-specific config |
 
 When set to `nil` (the default), the plugin will use snacks.nvim if available,
 otherwise it falls back to the builtin floating terminal.
+
+### Advanced Terminal Configuration
+
+You can pass provider-specific configuration by using a table format:
+
+```lua
+-- Snacks with custom window config
+require('external-tui').setup({
+  terminal_provider = {
+    snacks = {
+      win = { style = 'float', position = 'bottom' }
+    }
+  }
+})
+
+-- Builtin with custom dimensions
+require('external-tui').setup({
+  terminal_provider = {
+    builtin = {
+      width = 0.9,
+      height = 0.9,
+      border = 'single',
+      style = 'minimal',
+    }
+  }
+})
+```
+
+The presence of the `snacks` or `builtin` key determines which provider to use,
+and its value completely replaces the default configuration.
+
+For Snacks configuration options, see the
+[Snacks terminal documentation](https://github.com/folke/snacks.nvim/blob/main/docs/terminal.md).
+
+The builtin provider supports a limited set of options:
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `width` | `number` | `0.8` | Window width as percentage of editor (0.0-1.0) |
+| `height` | `number` | `0.8` | Window height as percentage of editor (0.0-1.0) |
+| `border` | `string` | `'rounded'` | Border style (see `:help nvim_open_win`) |
+| `style` | `string` | `'minimal'` | Window style (see `:help nvim_open_win`) |
+
+For more advanced terminal configuration, consider using Snacks.
 
 ## Usage
 

--- a/tests/integration/setup_spec.lua
+++ b/tests/integration/setup_spec.lua
@@ -44,6 +44,73 @@ describe('M.setup', function()
       external_tui.setup({ terminal_provider = 'builtin' })
     end)
   end)
+
+  it('accepts table-format terminal_provider with snacks config', function()
+    assert.has_no_error(function()
+      external_tui.setup({
+        terminal_provider = {
+          snacks = { win = { style = 'float' } },
+        },
+      })
+    end)
+  end)
+
+  it('accepts table-format terminal_provider with builtin config', function()
+    assert.has_no_error(function()
+      external_tui.setup({
+        terminal_provider = {
+          builtin = { width = 0.9, height = 0.9 },
+        },
+      })
+    end)
+  end)
+end)
+
+describe('normalize_terminal_provider', function()
+  local external_tui
+
+  before_each(function()
+    package.loaded['external-tui'] = nil
+    external_tui = require('external-tui')
+  end)
+
+  after_each(function()
+    package.loaded['external-tui'] = nil
+  end)
+
+  local normalize = function(provider)
+    return external_tui._private.normalize_terminal_provider(provider)
+  end
+
+  it('returns nil name and empty config for nil input', function()
+    local result = normalize(nil)
+    assert.is_nil(result.name)
+    assert.are.same({}, result.config)
+  end)
+
+  it('returns string name and empty config for string input', function()
+    local result = normalize('snacks')
+    assert.are.equal('snacks', result.name)
+    assert.are.same({}, result.config)
+  end)
+
+  it('extracts snacks name and config from table', function()
+    local result = normalize({ snacks = { win = { style = 'float' } } })
+    assert.are.equal('snacks', result.name)
+    assert.are.same({ win = { style = 'float' } }, result.config)
+  end)
+
+  it('extracts builtin name and config from table', function()
+    local result = normalize({ builtin = { width = 0.9 } })
+    assert.are.equal('builtin', result.name)
+    assert.are.same({ width = 0.9 }, result.config)
+  end)
+
+  it('returns nil name for empty table', function()
+    local result = normalize({})
+    assert.is_nil(result.name)
+    assert.are.same({}, result.config)
+  end)
 end)
 
 describe('terminal provider selection', function()


### PR DESCRIPTION
This adds an additional layer to the terminal_provider config option that takes a table instead of a string. If provided, the table will be used as the configuration for the created terminal instance. The builtin just supports minor changes such as altering the
width/height/border/style, but the Snacks terminal takes the full configuration options for Snacks itself, providing for significantly more control. We don't plan on supporting additional configuration for the builtin, anyone wanting more intricate configuration should look at using Snacks for the terminal provider.

Fixes #2